### PR TITLE
Fixing https upgrade script

### DIFF
--- a/whotracksme/qa/utils.py
+++ b/whotracksme/qa/utils.py
@@ -7,7 +7,7 @@ import json
 async def fetch(session, url):
     with async_timeout.timeout(10):
         try:
-            async with session.head(url) as response:
+            async with session.head(url, headers={'User-Agent': 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.12; rv:60.0) Gecko/20100101 Firefox/60.0'}) as response:
                 return {
                     "original_url": url,
                     "status": response.status,
@@ -30,11 +30,15 @@ async def fetch_all(session, urls, loop):
 
 def retrieve_status(urls):
     async def main(urls, loop):
-        conn = aiohttp.TCPConnector(verify_ssl=False)
+        conn = aiohttp.TCPConnector(verify_ssl=True) #verify_ssl needs to be true, otherwise it will accept invalid certificates.
         async with aiohttp.ClientSession(connector=conn) as session:
             return await fetch_all(session, urls, loop)
 
+    #https://docs.python.org/3.5/library/asyncio-eventloop.html#asyncio.AbstractEventLoop.set_exception_handler
+    def handler(self, context):
+        print(context['exception'])
     loop = asyncio.get_event_loop()
+    loop.set_exception_handler(handler)
     results = loop.run_until_complete(main(urls, loop))
     return results
 


### PR DESCRIPTION
Script to generate list of domains which can be upgraded to `https` was giving incorrect results, example for domains where the certificate is invalid, it should not be upgraded.

`verify_ssl=True` enforces, even if certificate is present, it should be valid.

We currently only print the certificate exception, as a different PR we should save it somewhere for different analysis.

Usage:
`python main.py db check_urls`

cc @ecnmst