### PR TITLE
Correct EU stats for September 2018

### DIFF
--- a/whotracksme/data/assets/2018-09/eu/trackers.csv
+++ b/whotracksme/data/assets/2018-09/eu/trackers.csv
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:79aa06ba50d56fa75b7e59931e62cf875907a12966815f719f86f22c51ddd07c
-size 276293
+oid sha256:946c33b55f12271debe6c8d2e85e4473c5fe8f9e67ac845a5f74976d35b03ed6
+size 269991


### PR DESCRIPTION
We observed an anomaly in the EU data for September caused by a failure when the job was running. I re-ran the aggregation by summing all the EU countries.