### PR TITLE
Bump pandas and numpy versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ certifi==2018.11.29
 chardet==3.0.4
 docopt==0.6.2
 idna==2.8
-numpy==1.15.4
-pandas==0.23.4
+numpy==1.19.1
+pandas==1.1.1
 python-dateutil==2.7.5
 pytz==2018.9
 requests==2.21.0


### PR DESCRIPTION
Without this, I can't successfully install this project on my Mac (MacOS 10.15.6, Python 3.8.1), because it throws an error while compiling pandas.