### PR TITLE
Ensure objects are readable after s3 upload

### DIFF
--- a/deploy_to_s3.py
+++ b/deploy_to_s3.py
@@ -114,14 +114,16 @@ if __name__ == '__main__':
         with open(local_path, 'rb') as fp:
             s3_client.put_object(Bucket=bucket_name, Key=s3_path, Body=fp,
                                  CacheControl=cache_control,
-                                 ContentType=content_type)
+                                 ContentType=content_type,
+                                 ACL='public-read')
 
         # setup redirects
         html_path = f'{s3_path}.html'
         if html_path in existing_keys:
             print(f'redirect {html_path} to /{s3_path}')
             s3_client.put_object(Bucket=bucket_name, Key=html_path,
-                                 WebsiteRedirectLocation=f'/{s3_path}')
+                                 WebsiteRedirectLocation=f'/{s3_path}',
+                                 ACL='public-read')
             # upload + redirect
             return True, True
         else:


### PR DESCRIPTION
Due to a change in the bucket configuration, we now have to manually specify the ACL when uploading to the `whotracksme` S3 bucket. Not doing so will lead to `403` errors on the CDN. This PR adds the correct ACL to uploads.